### PR TITLE
chore: resolve pytest upgrade test failures

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ ty==0.0.55
 voluptuous-stubs==0.1.1
 
 # Home Assistant testing dependencies
-pytest-homeassistant-custom-component==0.13.340
+pytest-homeassistant-custom-component==0.13.341
 syrupy>=4.6.1
 
 # Component dependencies

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -183,7 +183,7 @@ async def test_keypad_input(
 
     error_logs = [record for record in caplog.records if record.levelname == "ERROR"]
     assert len(error_logs) == 3
-    assert "Invalid alarm code" in error_logs[0].message
+    assert "invalid_code" in error_logs[0].message
     caplog.clear()
 
     # Verify device was not notified


### PR DESCRIPTION
Upgrades pytest-homeassistant-custom-component to 0.13.341 and fixes failing assertions on invalid alarm code.