### PR TITLE
fix(hacs): bump min homeassistant version to 2026.8.0b0

### DIFF
--- a/custom_components/ring_keypad/__init__.py
+++ b/custom_components/ring_keypad/__init__.py
@@ -157,7 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("Removing Ring Keypad configuration entry")
             await hass.config_entries.async_remove(entry.entry_id)
         elif action == "update":
-            changes = event.data["changes"]  # type: ignore[typeddict-item]  # ty:ignore[invalid-key]
+            changes = event.data["changes"]  # type: ignore[typeddict-item]
             if "name" in changes:
                 _LOGGER.debug("Reloading Ring Keypad configuration entry")
                 await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/ring_keypad/__init__.py
+++ b/custom_components/ring_keypad/__init__.py
@@ -157,8 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("Removing Ring Keypad configuration entry")
             await hass.config_entries.async_remove(entry.entry_id)
         elif action == "update":
-            changes = event.data["changes"]  # type: ignore[typeddict-item]
-            if "name" in changes:
+            if (changes := event.data.get("changes")) and "name" in changes:
                 _LOGGER.debug("Reloading Ring Keypad configuration entry")
                 await hass.config_entries.async_reload(entry.entry_id)
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Ring Keypad",
-  "homeassistant": "2025.11.0"
+  "homeassistant": "2026.8.0b0"
 }


### PR DESCRIPTION
Fixes #125

Bumps the minimum required Home Assistant version in `hacs.json` to `2026.8.0b0`.

Recent releases of this integration introduced `async_remove_helper_devices` which was added in Home Assistant 2026.8.0. Specifying `2026.8.0b0` ensures HACS allows installations on 2026.8 beta and stable releases while preventing failures on 2026.7.x.